### PR TITLE
Fix autoloader

### DIFF
--- a/resources/autoload.php
+++ b/resources/autoload.php
@@ -22,7 +22,7 @@ spl_autoload_register(
             return;
         }
         $relative_class = substr($class, $len);
-        $file = dirname(__DIR__).'/'.str_replace('\\', '/', $relative_class).'.php';
+        $file = dirname(dirname(__DIR__)).'/'.str_replace('\\', '/', $relative_class).'.php';
         if (file_exists($file)) {
             require $file;
         }


### PR DESCRIPTION
Can you please review this (not yet tested)

IIUC, autoloader is able to manage the complete "Com\Tecnick" namespace
(whatever the  component it comes from, simpler, and thus avoid having to manage dep.).

in tc-lib-color, autoloader it is installed in 
/usr/share/php/Com/Tecnick/Color/autoload.php

but in tc-lib-pdf-filter, it is in 
/usr/share/php/Com/Tecnick/Pdf/Filter/autoload.php

So you need to go up twice.
