### PR TITLE
Use standardized license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP library to decode PDF compression and encryption filters",
     "type": "library",
     "homepage": "http://www.tecnick.com",
-    "license": "GNU-LGPL v3",
+    "license": "LGPL-3.0",
     "keywords": ["tc-lib-pdf-filter", "PDF", "filter", "encryption", "compression"],
     "authors": [
         {


### PR DESCRIPTION
SPDX has standardized the license identifiers to avoid confusions and allow tool-assisted license checks
https://spdx.org/licenses/
